### PR TITLE
Refactor IAuth and the way SessionController interacts with it

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -7,6 +7,8 @@ After:
 Injector:
   Authenticator:
     class: TokenAuth
+  ApiMemberAuthenticator:
+    class: MemberAuthenticor
 TokenAuth:
   DevToken: foobarbaz
 JwtAuth:

--- a/code/authenticators/IAuth.php
+++ b/code/authenticators/IAuth.php
@@ -8,9 +8,16 @@ interface IAuth {
     /**
      * @param string $email the email of the
      * @param string $password
-     * @return \Ntb\ApiSession
+     * @deprecated - use createSession instead
+     * @return ApiSession
      */
     public static function authenticate($email, $password);
+
+	/**
+	 * @param Member $member
+	 * @return ApiSession
+	 */
+	public static function createSession($member);
 
     /**
      * @param SS_HTTPRequest $request

--- a/code/authenticators/JwtAuth.php
+++ b/code/authenticators/JwtAuth.php
@@ -8,17 +8,25 @@
 class JwtAuth extends Object implements IAuth {
 
     public static function authenticate($email, $password) {
-        $authenticator = new MemberAuthenticator();
+        $authenticator = Injector::inst()->get('ApiMemberAuthenticator');
         if($user = $authenticator->authenticate(['Password' => $password, 'Email' => $email])) {
-            // create session
-            $session = ApiSession::create();
-            $session->User = $user;
-            $session->Token = JwtAuth::generate_token($user);
-            return $session;
+	        return self::createSession($user);
         }
     }
 
-    public static function delete($request) {
+	/**
+	 * @param Member $user
+	 * @return ApiSession
+	 */
+	public static function createSession($user) {
+		// create session
+		$session = ApiSession::create();
+		$session->User = $user;
+		$session->Token = JwtAuth::generate_token($user);
+		return $session;
+	}
+
+	public static function delete($request) {
         // nothing to do here
     }
 
@@ -37,7 +45,7 @@ class JwtAuth extends Object implements IAuth {
     }
 
     /**
-     * 
+     *
      *
      * @param string $token
      * @throws RestUserException
@@ -128,4 +136,5 @@ class JwtAuth extends Object implements IAuth {
     static function base64_url_decode($base64) {
         return base64_decode(strtr($base64, '-_', '+/'));
     }
+
 }

--- a/code/formatters/SessionFormatter.php
+++ b/code/formatters/SessionFormatter.php
@@ -8,7 +8,7 @@ class SessionFormatter implements IRestSerializeFormatter {
     /**
      * Returns an array with entries for `user`.
      *
-     * @param Ntb\ApiSession $data
+     * @param ApiSession $data
      * @param array $access
      * @param array $fields
      * @return array the user data in a serializable structure


### PR DESCRIPTION
This is a cleaner architecture that eliminates some boilerplate and adds flexibility for extension. IAuth is really only concerned with creating an ApiSession from a Member, and resuming that session in future requests. It shouldn't specifically be limited to Email + Password. That's what MemberAuthenticator in the SilverStripe core is for. This PR also makes "MemberAuthenticator" injectable so it can be swapped out if needed rather than hardcoded (i.e. `new MemberAuthenticator()`).

These changes are needed for #11 to work well, but I think they would be an improvement anyway.