### PR TITLE
FIX Update constraint so as not to indicate SilverStripe 4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "api"
   ],
   "require": {
-    "silverstripe/framework": ">=3.1.13",
+    "silverstripe/framework": "^3.1.13",
     "php": ">=5.3.2",
     "composer/installers": "*"
   },


### PR DESCRIPTION
`>=3` is compliant with 4.0.0 when it shouldn't be, this PR switches it for a safer constraint